### PR TITLE
Added fix to prevent index.html appearing in browser history on initialisation

### DIFF
--- a/js/adapt-pageMenuRouter.js
+++ b/js/adapt-pageMenuRouter.js
@@ -218,7 +218,7 @@ define(function(require) {
 					Backbone.history.navigate("#/id/"+to, {trigger: true, replace: replaceUrl});
 					break;
 				default:
-					Adapt.navigateToElement("." + to, undefined, undefined, replaceUrl);		
+					Adapt.navigateToElement("." + to);		
 					break;
 				}
 			}


### PR DESCRIPTION
Requires replaceUrl branch from adapt-framework-kineoFork
